### PR TITLE
client: added auto host bool to hosted event

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -792,15 +792,15 @@ client.prototype.handleMessage = function handleMessage(message) {
                     // Message from JTV..
                     else if (message.tags.username === "jtv") {
                         // Someone is hosting the channel and the message contains how many viewers..
-                        if (msg.includes("is now hosting you for")) {
+                        if (msg.includes("hosting you for")) {
                             var count = _.extractNumber(msg);
 
-                            this.emit("hosted", channel, _.username(msg.split(" ")[0]), count);
+                            this.emit("hosted", channel, _.username(msg.split(" ")[0]), count, msg.includes("auto"));
                         }
 
                         // Some is hosting the channel, but no viewer(s) count provided in the message..
-                        else if (msg.includes("is now hosting you")) {
-                            this.emit("hosted", channel, _.username(msg.split(" ")[0]), 0);
+                        else if (msg.includes("hosting you")) {
+                            this.emit("hosted", channel, _.username(msg.split(" ")[0]), 0, msg.includes("auto"));
                         }
                     }
 


### PR DESCRIPTION
Added a bool parameter to the hosted event showing if the host was an auto-host. The message I based my changes off of was: ``DBKynd is now auto hosting you.`` 

I'm making an assumption here that the message for auto host with viewers would be ``DBKynd is now auto hosting you for 10 viewers.`` as I don't have an easy method for testing without setting up alt accounts to 'view' and then host.